### PR TITLE
Remove .h.in files from podspec

### DIFF
--- a/glog.podspec
+++ b/glog.podspec
@@ -10,8 +10,6 @@ Pod::Spec.new do |spec|
   spec.module_name = 'glog'
   spec.header_dir = 'glog'
   spec.source_files = 'src/glog/*.h',
-                      'src/glog/*.h.in',
-                      'src/*.h.in',
                       'src/demangle.cc',
                       'src/logging.cc',
                       'src/raw_logging.cc',


### PR DESCRIPTION
Remove .h.in files from podspec since XCode does not know how to handle .in files, and the .h files seem to be used as is from the repo - i.e. they seem to be pre-generated.